### PR TITLE
 - Removing scientific notation for outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ For a file that has suspected CNVs:
 ```
 ./scripts/run_pipeline.sh -f <bam_filename> --is_input_control TRUE --params_output params_input_control.txt \
   --pbs_output pbs_input_control.bed --cnv_rescale_success_output cnv_rescale_input_control.txt \
-  --bypass_cnv_rescaling_step FALSE --cnv_ratios_filename cnv_ratios.txt
+  --bypass_cnv_rescaling_step FALSE --cnv_ratios_filename input_control_cnv_ratios.txt
 ```
 
->Note that if the fourth column in `cnv_ratios.txt` is all `1`, then no CNVs were detected in the input control.
+>Note that if the fourth column in `input_control_cnv_ratios.txt` is all `1`, then no CNVs were detected in the input control.
 
-2. Process an epitope file, using `cnv_ratios.txt` as the file for rescaling:
+2. Process an epitope file, using `input_control_cnv_ratios.txt` as the file for rescaling:
 ```
 ./scripts/run_pipeline.sh -f <bam_filename> --is_input_control FALSE --params_output params.txt \
   --pbs_output pbs.bed --cnv_rescale_success_output cnv_rescale.txt --bypass_cnv_rescaling_step FALSE \
-  --cnv_ratios_filename cnv_ratios.txt
+  --cnv_ratios_filename input_control_cnv_ratios.txt
 ```
 
 

--- a/scripts/binning/makeBins.R
+++ b/scripts/binning/makeBins.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 # Generate reference files of bins
 # Expects genome assembly first, bin width second
 library('rtracklayer')

--- a/scripts/cnvRescaling/CNVRescale.R
+++ b/scripts/cnvRescaling/CNVRescale.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 suppressPackageStartupMessages(library(plyr))
 suppressPackageStartupMessages(library(dplyr))
 suppressPackageStartupMessages(library(ggplot2))

--- a/scripts/cnvRescaling/SubmitCNVRescale.R
+++ b/scripts/cnvRescaling/SubmitCNVRescale.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 suppressPackageStartupMessages(library(optparse))
 suppressPackageStartupMessages(library(data.table))
 

--- a/scripts/pbs/ProbabilityBeingSignal.R
+++ b/scripts/pbs/ProbabilityBeingSignal.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 suppressPackageStartupMessages(library(data.table))
 suppressPackageStartupMessages(library(dplyr))
 suppressPackageStartupMessages(library(ggplot2))

--- a/scripts/pbs/SubmitProbabilityBeingSignal.R
+++ b/scripts/pbs/SubmitProbabilityBeingSignal.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 suppressPackageStartupMessages(library(optparse))
 suppressPackageStartupMessages(library(data.table))
 

--- a/scripts/rescaling/RescaleBinnedFiles.R
+++ b/scripts/rescaling/RescaleBinnedFiles.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 suppressPackageStartupMessages(library(dplyr))
 suppressPackageStartupMessages(library(data.table))
 

--- a/scripts/rescaling/SubmitRescaleBinnedFiles.R
+++ b/scripts/rescaling/SubmitRescaleBinnedFiles.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+options(scipen = 999)
+
 library(optparse)
 
 # infer script directory from command arguments


### PR DESCRIPTION
I added `options(scipen = 999)` to the R scripts, probably even in more file than required. This should fix the corrupted bed files that are produced.

I also made a change in the README to make even more obvious how to use the cvn files. 