### PR TITLE
Fix hg38

### DIFF
--- a/scripts/cnvRescaling/CNVRescale.R
+++ b/scripts/cnvRescaling/CNVRescale.R
@@ -124,7 +124,7 @@ GetCNVWithCNAnorm <- function(bin_size = 5000, saved_gc_filename = NULL, assembl
   }
   covData <- left_join(x = sample_df, y = reference_df, by = c('chr', 'start', 'end'))
   # correct for GC content in bins; GCcontent is in biovizBase; may need to be reloaded?
-  if(!is.null(saved_gc_filename)){
+  if(file.exists(saved_gc_filename)){
     gc_df <- fread(input = saved_gc_filename, col.names = c('chr', 'start', 'end', 'gc'))
   } else{
     print('Calculating GC content...')

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -21,7 +21,6 @@ CNV_RATIOS_FILENAME=NULL
 
 SCRIPTS_DIR=$(dirname "$0")
 REFS_DIR="${SCRIPTS_DIR}/../references"
-GC_CONTENT_FILENAME="${REFS_DIR}/${GENOME}_${BIN_SIZE}_gc.bed"
 
 
 while [ $# -gt 0 ]
@@ -114,6 +113,7 @@ do
     esac
 done
 
+GC_CONTENT_FILENAME="${REFS_DIR}/${GENOME}_${BIN_SIZE}_gc.bed"  
 
 
 # binning


### PR DESCRIPTION
I have been trying to run PBS with hg38, which has no GC reference file in ```references/```.

However, I was confused to see that running PBS using the ```-g hg38``` option did not create a new GC reference file as expected from the code. Also, it did not print the ```Calculating GC content...``` line either.

Looking closer at the source code, I found two causes:
- The ```run_pipeline.sh``` file did not update the default value of the ```GC_CONTENT_FILENAME``` variable with user input, since it is before argument parsing. I moved it after the argument parsing block.
- The ```CNVrescale.R``` file did not really check if a reference file exists. It only checked if the ```saved_gc_filename``` variable was not null. I noticed that GC content was neither computed nor taken into account downstream. I changed the condition to checking whether the file exists.

Combined, these two changes successfully implement GC content for hg38 when provided as input to ```run_pipeline.sh```.